### PR TITLE
口座情報入力画面を追加

### DIFF
--- a/public/css/mobile_inputaccountinfo.css
+++ b/public/css/mobile_inputaccountinfo.css
@@ -1,0 +1,105 @@
+body{
+    display: block;
+    background: #F7AB19;
+    font-family: 'ヒラギノ丸ゴ ProN','Hiragino Maru Gothic ProN',sans-serif;
+    margin: 0px;
+    padding: 0px;
+    
+}
+    .iphoneX{
+        background-color:#F7AB19;
+        width:375px;
+        height:812px;
+        position:relative;
+        top:0;
+        margin:0 auto;
+
+    }
+    
+    h1{
+        color:#000000;
+        text-align:center;
+        margin-top:0px;
+        background-size:cover;
+        height:161px;
+        vertical-align:middle;
+        max-width: 900px;
+        position: absolute;
+        max-width: 900px;
+        border: 3px solid #F7AB19;
+        width: 375px;
+        height: 58px;
+        box-sizing: border-box;
+        padding: 10px;
+    }
+
+    .questiontitle {
+        
+        font-size:13px;
+        color:#000000;
+    }
+    .title_branchnumber{
+        position:absolute;
+        top:20%;
+        left:10%;
+    }
+    .title_accountnumber{
+        position:absolute;
+        top:29%;
+        left:10%;
+    }
+    .title_token{
+        position:absolute;
+        top:38%;
+        left:10%;
+    }
+    
+    
+    .questioncolum{
+        position:absolute;
+        width:283.62px;
+        height:30px;
+        font-size:14px;
+        border-radius:20px;
+        text-align:center;
+        margin-bottom:5px;
+        border: 3px solid #FFFFFF;
+    }
+    .branchnumbercolum{
+        position:absolute;
+        top:23%;
+        left:10%;
+        
+    }
+    .accountnumbercolum{
+        position:absolute;
+        top:32%;
+        left:10%;
+    }
+    .tokencolum{
+        position:absolute;
+        top:41%;
+        left:10%;
+    }
+    
+    
+
+    .submitbottom {
+        position:absolute;
+        top:77%;
+        left:10%;
+        background-color:#119A81;
+        box-shadow:0px 0px 0px;
+        width:285px;
+        height:60px;
+        text-align:center;
+        margin-top:10px;
+        border-radius:45px;
+        color:#FFFFFF;
+        font-size:18px;
+        border: 3px solid #119A81;
+    }
+
+
+
+

--- a/resources/views/layouts/inputaccountinfo.html
+++ b/resources/views/layouts/inputaccountinfo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link rel="stylesheet"  href="mobile_inputaccountinfo.css">
+        <!--<link rel="srylesheet" media="(min-widtn: 900px)" href="pc_createaccount.css">-->
+        <title>口座情報入力</title>
+    </head>
+
+    <body>
+        <div class="iphoneX">
+            <div class="title">
+                <h1>口座情報を入力してください</h1>
+            </div>
+
+
+            <div class="inputaccountinfo-container">
+
+                <form action="#" method="post">
+                    <div class="questiontitle title_branchnumber">
+                        <label for="askbranchnumber">支店番号:</label>
+                    </div>
+                    <div>
+                        <input type="number" id="askbranchnumber" required class="questioncolum branchnumbercolum">
+                    </div>
+                    <div class="questiontitle title_accountnumber">
+                        <label for="addaccountnumber">口座番号:</label>
+                    </div>
+                    <div>
+                        <input type="number" id="addaccountnumber" required class="questioncolum accountnumbercolum">
+                    </div>
+                    <div class="questiontitle title_token">
+                        <label for="addtoken">トークン:</label>
+                    </div>
+                    <div>
+                        <input type="text" id="addtoken" required class="questioncolum tokencolum">
+                    </div>
+                    
+
+                    <input type="submit" name="submitvalue" value="口座情報登録" class="submitbottom">
+
+                </form>        
+            </div>
+
+        </div>
+
+        
+
+</body>
+</html>


### PR DESCRIPTION
以下の内容を追加
支店番号、口座番号、トークン入力箇所生成
バリデーションで数字の制限を追加
基本的にcreateaccount.[html,css]を流用

課題
- 入力可能の数字の文字数の制限等ができていない